### PR TITLE
Changed base URL to https to ensure secure loading of JS and CSS

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -17,7 +17,7 @@ title: "Hello. I'm Jami Gibbs."
 email: 'jami0821@gmail.com'
 description: "I'm a software developer and designer from Chicago creating useful things for the web."
 baseurl: "" # the subpath of your site, e.g. /blog
-url: "http://jamigibbs.github.io/phantom" # the base hostname & protocol for your site, e.g. http://example.com
+url: "https://jamigibbs.github.io/phantom" # the base hostname & protocol for your site, e.g. https://example.com
 twitter_username: 'jamigibbs'
 github_username: 'jamigibbs'
 medium_username: 'blog.jamigibbs.com'


### PR DESCRIPTION
Currently, the live demo is not rendered correctly due to the fact that most browsers block the loading of unsecured HTTP content - see #16 

Changing of the base URL to https:// fixes this issue.