### PR TITLE
Bump dependency versions

### DIFF
--- a/phantom.gemspec
+++ b/phantom.gemspec
@@ -12,9 +12,9 @@ Gem::Specification.new do |spec|
 
   spec.files         = `git ls-files -z`.split("\x0").select { |f| f.match(%r!^(assets|_layouts|_includes|_sass|LICENSE|README)!i) }
 
-  spec.add_runtime_dependency "jekyll", "~> 3.8"
+  spec.add_runtime_dependency "jekyll", "~> 4.0"
 
-  spec.add_development_dependency "bundler", "~> 2.0"
-  spec.add_development_dependency "rake", "~> 12.3"
-  spec.add_development_dependency "jekyll-paginate-v2", "~> 2.0"
+  spec.add_development_dependency "bundler", "~> 2.1"
+  spec.add_development_dependency "rake", "~> 13.0"
+  spec.add_development_dependency "jekyll-paginate-v2", "~> 3.0"
 end


### PR DESCRIPTION
Hey jamigibbs,

thank you for your awesome template, I am building my personal page ontop of it.
Ruby-sass, a dependency of Jekyll 3.x is deprecated by now. Jekyll 4.0 is stable and utitlizes a new lib for sass compilation. I bumped versions of all dependenciess. At least the demo page renders just finde. Pagination works as well.